### PR TITLE
fix: content-type detection

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -103,7 +103,7 @@ export const withHtmlLiveReload = <
 
       const response = await serveOptions.fetch(req, server);
 
-      if (response.headers.get("Content-Type") !== "text/html") {
+      if (!response.headers.get("Content-Type")?.startsWith("text/html")) {
         return response;
       }
 


### PR DESCRIPTION
👋 Hey there,

This one expands the content-type detection to allow for content-types that carry encoding settings (e.g. `text/html; charset=utf8`).

One could use an external lib such as [type-is](https://www.npmjs.com/package/type-is), but perhaps the suggestion on this PR is good enough for this lib's needs.

Cheers.