### PR TITLE
Better handling of the host in wsUrl

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -86,8 +86,8 @@ export const withHtmlLiveReload = <
   return {
     ...serveOptions,
     fetch: async (req, server) => {
-      const wsUrl = `${server.hostname}:${server.port}/${wsPath}`;
-      if (req.url === `http://${wsUrl}`) {
+      const reqUrl = new URL(req.url);
+      if (reqUrl.pathname === '/' + wsPath) {
         const upgraded = server.upgrade(req);
 
         if (!upgraded) {
@@ -106,7 +106,7 @@ export const withHtmlLiveReload = <
       }
 
       const originalHtml = await response.text();
-      const liveReloadScript = makeLiveReloadScript(wsUrl);
+      const liveReloadScript = makeLiveReloadScript(`${reqUrl.host}/${wsPath}`);
       const htmlWithLiveReload = originalHtml + liveReloadScript;
 
       return new Response(htmlWithLiveReload, response);


### PR DESCRIPTION
Hello! I've encountered the problem that `server.hostname` doesn't always match the host, to which request is sent from developer's browser. I'm developing on remote, so, for me, `server.hostname` evaluates to `0.0.0.0`, but from my local machine I make requests to `my-development-domain.com`. This results in 2 problems:

- Failing to detect http request to websocket url (which should be upgraded)
- Wrong URL in live reload script on the frontend

This PR replaces usage of `server.hostname` and `server.port` with getting those values from the `request.url`