### PR TITLE
fix: close SSE connection on beforeunload event

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -87,9 +87,11 @@ export function withHtmlLiveReload(
 
     if (requestUrl.pathname === scriptPath) {
       return new Response(
-        `new EventSource("${eventPath}").onmessage = function(msg) {  
+        `const sse = new EventSource("${eventPath}");
+         sse.onmessage = function(msg) {
           if(msg.data === 'RELOAD') { location.reload(); }
-         };`,
+         };
+         window.addEventListener('beforeunload', () => sse.close());`,
         { headers: { "Content-Type": "text/javascript" } },
       );
     }


### PR DESCRIPTION
Add explicit cleanup of EventSource connection when the page unloads to prevent SSE connections from remaining open during navigation. This fixes an issue where browsers hit their connection limit when servers have high idle timeouts.

Fixes #10 